### PR TITLE
Issue 69 - Fix cursor getting stuck on wrong icon; fix hover effects on title bar

### DIFF
--- a/beams/app/resources/light_style.qss
+++ b/beams/app/resources/light_style.qss
@@ -58,7 +58,7 @@ StyleOneToolButton {
 }
 
 StyleOneToolButton:hover:!pressed {
-    background-color: @contrast;
+    background-color: @brand_minus_one;
 }
 
 StyleOneDockWidget {
@@ -93,43 +93,6 @@ QListWidget::item:selected:!active {
     background: @low_contrast;
 }
 
-
-QTabWidget::pane { /* The tab widget frame */
-    background: #FFFFFF;
-}
-
-QTabWidget::tab-bar {
-    background: pink;
-    border-top: 5px solid red;
-}
-
-QTabBar {
-    background: @brand_zero;
-    border-top: None;
-    margin-top: 0px;
-    padding: 0px;
-}
-
-/* Style the tab using the tab sub-control. Note that it reads QTabBar _not_ QTabWidget */
-QTabBar::tab {
-    background: #070536;
-    min-width: 45px;
-    max-width: 45px;
-    min-height: 45px;
-    max-height: 45px;
-    padding: 0px;
-    padding-left:20px;
-    padding-right:20px;
-    font: bold 12px;
-    color: #FFFFFF;
-}
-QTabBar::tab:selected, QTabBar::tab:hover {
-    background: #000031;
-}
-QTabBar::tab:selected {
-    border-color: #000031;
-    border-bottom-color: #FFFFFF; /* same as pane color */
-}
 
 
 

--- a/beams/app/util/widgets.py
+++ b/beams/app/util/widgets.py
@@ -159,12 +159,16 @@ class TitleBar(QtWidgets.QWidget):
 
         self.minimize = StyleOneToolButton()
         self.minimize.setFixedWidth(40)
+        self.minimize.setFixedHeight(40)
 
         self.maximize = StyleOneToolButton()
         self.maximize.setFixedWidth(40)
+        self.maximize.setFixedHeight(40)
 
         self.close = StyleOneToolButton()
         self.close.setFixedWidth(40)
+        self.close.setFixedHeight(40)
+        self.close.setStyleSheet("StyleOneToolButton:hover:!pressed { background-color: #ff3333 }")
 
         pix = QtGui.QIcon(resources.CLOSE_IMAGE)
         self.close.setIcon(pix)


### PR DESCRIPTION
Turns out this is because the frame wasn't getting a mouse move event when the mouse moves too quickly across it (not actually touching the frame). I increased the width of the frame a bit and haven't been able to get the cursor stuck again so we will see if this fixes it.