### PR TITLE
Issue 87 - Fix for asymmetries not updating to histogram changes

### DIFF
--- a/beams/app/gui/histogrampanel.py
+++ b/beams/app/gui/histogrampanel.py
@@ -661,18 +661,25 @@ class HistogramPanelPresenter(PanelPresenter):
                          self.__current_histogram.good_bin_end)
 
     def _save_clicked(self):
-        print(self.__alterations)
-
+        altered_run_ids = []
         for histogram in self._view.support_panel.tree.get_all_histograms():
             if histogram.id in self.__alterations.keys() and histogram.title in self.__alterations[histogram.id].keys():
+                if histogram.background_start != self.__alterations[histogram.id][histogram.title][files.BACKGROUND_ONE_KEY] \
+                        or histogram.background_end != self.__alterations[histogram.id][histogram.title][files.BACKGROUND_TWO_KEY] \
+                        or histogram.time_zero != self.__alterations[histogram.id][histogram.title][files.T0_KEY] \
+                        or histogram.good_bin_start != self.__alterations[histogram.id][histogram.title][files.GOOD_BIN_ONE_KEY] \
+                        or histogram.good_bin_end != self.__alterations[histogram.id][histogram.title][files.GOOD_BIN_TWO_KEY]:
+                    altered_run_ids.append(histogram.id)
+                else:
+                    continue
+
                 histogram.background_start = self.__alterations[histogram.id][histogram.title][files.BACKGROUND_ONE_KEY]
                 histogram.background_end = self.__alterations[histogram.id][histogram.title][files.BACKGROUND_TWO_KEY]
                 histogram.time_zero = self.__alterations[histogram.id][histogram.title][files.T0_KEY]
                 histogram.good_bin_start = self.__alterations[histogram.id][histogram.title][files.GOOD_BIN_ONE_KEY]
                 histogram.good_bin_end = self.__alterations[histogram.id][histogram.title][files.GOOD_BIN_TWO_KEY]
-                print(histogram.background_start, histogram.background_end, histogram.time_zero, histogram.good_bin_start, histogram.good_bin_end)
 
-        self.__run_service.recalculate_asymmetries(self._view.support_panel.tree.get_selected_run_ids())
+        self.__run_service.recalculate_asymmetries(altered_run_ids)
 
     def _editing_checked(self):
         self.__editing = self._view.is_editing()


### PR DESCRIPTION
We keep a dictionary of alterations and we were only updating the alterations for the histograms that were selected. This may have been a feature in my mind but I think this way is better. So when you hit save, it will save every alteration you have made to every histogram and recalculate the affected asymmetries.