### PR TITLE
Issue 111 - Fix visual issues with main window

### DIFF
--- a/beams/app/gui/consolepanel.py
+++ b/beams/app/gui/consolepanel.py
@@ -340,13 +340,9 @@ class MainConsolePanel(QtWidgets.QDockWidget):
         # Set Widget Dimensions
 
         self.select_all.setFixedWidth(20)
-        self.import_button.setFixedWidth(25)
-        self.remove_button.setFixedWidth(25)
-        self.convert_button.setFixedWidth(60)
-        self.write_button.setFixedWidth(40)
-        self.load_button.setFixedWidth(40)
+        self.import_button.setFixedWidth(20)
+        self.remove_button.setFixedWidth(20)
         self.setMaximumHeight(350)
-        self.setMaximumWidth(350)
 
         # Set Widget Tooltips
         self.write_button.setToolTip('Write currently plotted data to .asy files')
@@ -358,9 +354,7 @@ class MainConsolePanel(QtWidgets.QDockWidget):
 
         # Layout Widgets
         hbox_one = QtWidgets.QHBoxLayout()
-        hbox_one.setSpacing(10)
         hbox_one.addWidget(self.select_all)
-        hbox_one.addSpacing(5)
         hbox_one.addWidget(self.import_button)
         hbox_one.addWidget(self.remove_button)
         hbox_one.addWidget(self.convert_button)

--- a/beams/app/gui/plottingpanel.py
+++ b/beams/app/gui/plottingpanel.py
@@ -710,7 +710,7 @@ class PlottingPanel(Panel, QtWidgets.QWidget):
             pass
 
         def _set_widget_dimensions(self):
-            box_size = 40
+            box_size = 20
             self.input_time_xmin.setMinimumWidth(box_size)
             self.input_time_xmax.setMinimumWidth(box_size)
             self.input_time_ymin.setMinimumWidth(box_size)
@@ -995,12 +995,12 @@ class PlottingPanel(Panel, QtWidgets.QWidget):
         hbox = QtWidgets.QHBoxLayout()
 
         vbox = QtWidgets.QVBoxLayout()
-        vbox.addWidget(self.left_display, 2)
+        vbox.addWidget(self.left_display, 5)
         vbox.addWidget(self.left_settings)
         hbox.addLayout(vbox)
 
         vbox = QtWidgets.QVBoxLayout()
-        vbox.addWidget(self.right_display, 2)
+        vbox.addWidget(self.right_display, 5)
         vbox.addWidget(self.right_settings)
         hbox.addLayout(vbox)
 


### PR DESCRIPTION
The issue with truncated text seems to just be tied to whether or not you have PyQt5 installed or QtPy. 
Reduced the minimum size of the screen by adjusting the minimum widths of the buttons above the main file tree.