### PR TITLE
MAINT - Renaming event handlers

### DIFF
--- a/beams/app/gui/dialogs/dialog_isis_download.py
+++ b/beams/app/gui/dialogs/dialog_isis_download.py
@@ -228,11 +228,11 @@ class ISISDownloadDialogPresenter:
         self._set_callbacks()
 
     def _set_callbacks(self):
-        self._view.search_button.released.connect(lambda: self._search_clicked())
-        self._view.done_button.released.connect(lambda: self._done_clicked())
-        self._view.select_button.released.connect(lambda: self._save_to_clicked())
-        self._view.download_selected.released.connect(lambda: self._download_selected_clicked())
-        self._view.download_all.released.connect(lambda: self._download_all_clicked())
+        self._view.search_button.released.connect(self._on_search_clicked)
+        self._view.done_button.released.connect(self._on_done_clicked)
+        self._view.select_button.released.connect(self._on_save_to_clicked)
+        self._view.download_selected.released.connect(self._on_download_selected_clicked)
+        self._view.download_all.released.connect(self._on_download_all_clicked)
 
     def _assemble_save(self):
         directory = self._view.get_file()
@@ -242,7 +242,7 @@ class ISISDownloadDialogPresenter:
 
         return directory
 
-    def _search_clicked(self):
+    def _on_search_clicked(self):
         self._view.set_status_message('Querying ... ')
         self._view.setEnabled(False)
         QtCore.QCoreApplication.processEvents()
@@ -250,7 +250,7 @@ class ISISDownloadDialogPresenter:
         self._view.setEnabled(True)
         self._view.set_status_message('Done.')
 
-    def _download_selected_clicked(self):
+    def _on_download_selected_clicked(self):
         self._view.set_status_message('Downloading ... ')
         self._view.setEnabled(False)
         QtCore.QCoreApplication.processEvents()
@@ -258,7 +258,7 @@ class ISISDownloadDialogPresenter:
         self._view.setEnabled(True)
         self._view.set_status_message('Done')
 
-    def _download_all_clicked(self):
+    def _on_download_all_clicked(self):
         self._view.set_status_message('Downloading ... ')
         self._view.setEnabled(False)
         QtCore.QCoreApplication.processEvents()
@@ -266,7 +266,15 @@ class ISISDownloadDialogPresenter:
         self._view.setEnabled(True)
         self._view.set_status_message('Done')
 
-    def _done_clicked(self):
+    def _on_save_to_clicked(self):
+        path = QtWidgets.QFileDialog.getExistingDirectory(self._view, 'Select directory to save MUD files to',
+                                                          self.__system_service.get_last_used_directory(),
+                                                          options=QtWidgets.QFileDialog.ShowDirsOnly)
+        if path:
+            self.__system_service.set_last_used_directory(path)
+            self._view.set_file(path)
+
+    def _on_done_clicked(self):
         if self._new_files:
             self._view.done(ISISDownloadDialog.Codes.NEW_FILES)
         else:
@@ -439,12 +447,3 @@ class ISISDownloadDialogPresenter:
         self._new_files = True
         self._view.log_message('{} Files downloaded successfully.\n'.format(len(new_files)))
         self._view.set_status_message('Done.')
-
-    # noinspection PyCallByClass
-    def _save_to_clicked(self):
-        path = QtWidgets.QFileDialog.getExistingDirectory(self._view, 'Select directory to save MUD files to',
-                                                          self.__system_service.get_last_used_directory(),
-                                                          options=QtWidgets.QFileDialog.ShowDirsOnly)
-        if path:
-            self.__system_service.set_last_used_directory(path)
-            self._view.set_file(path)

--- a/beams/app/gui/dialogs/dialog_misc.py
+++ b/beams/app/gui/dialogs/dialog_misc.py
@@ -97,9 +97,9 @@ class WarningMessageDialog(QtWidgets.QDialog):
         pos_button.setFixedWidth(80)
 
         if pos_function:
-            pos_button.released.connect(lambda: pos_function())
+            pos_button.released.connect(pos_function)
 
-        pos_button.released.connect(lambda: self.close())
+        pos_button.released.connect(self.close)
 
         col = QtWidgets.QVBoxLayout()
 
@@ -136,8 +136,8 @@ class PermissionsMessageDialog(QtWidgets.QDialog):
 
         self.neg_button.released.connect(lambda: self.done(PermissionsMessageDialog.Codes.CANCEL))
 
-        self.neg_button.released.connect(lambda: self.close())
-        self.pos_button.released.connect(lambda: self.close())
+        self.neg_button.released.connect(self.close)
+        self.pos_button.released.connect(self.close)
 
         col = QtWidgets.QVBoxLayout()
         col.addWidget(message)

--- a/beams/app/gui/dialogs/dialog_musr_download.py
+++ b/beams/app/gui/dialogs/dialog_musr_download.py
@@ -226,12 +226,117 @@ class MusrDownloadDialogPresenter:
         self._set_callbacks()
 
     def _set_callbacks(self):
-        self._view.search_button.released.connect(lambda: self._search_clicked())
-        self._view.download_button.released.connect(lambda: self._download_clicked())
-        self._view.done_button.released.connect(lambda: self._done_clicked())
-        self._view.select_button.released.connect(lambda: self._save_to_clicked())
-        self._view.download_selected.released.connect(lambda: self._download_selected_clicked())
-        self._view.download_all.released.connect(lambda: self._download_all_clicked())
+        self._view.search_button.released.connect(self._on_search_clicked)
+        self._view.download_button.released.connect(self._on_download_clicked)
+        self._view.done_button.released.connect(self._on_done_clicked)
+        self._view.select_button.released.connect(self._on_save_to_clicked)
+        self._view.download_selected.released.connect(self._on_download_selected_clicked)
+        self._view.download_all.released.connect(self._on_download_all_clicked)
+
+    def _on_search_clicked(self):
+        self._view.set_status_message('Querying ... ')
+        query = self._assemble_query()
+
+        if query is None:
+            return
+
+        if len(query) < 2:
+            self._view.log_message("No query parameters filled.\n")
+        else:
+            self._view.log_message("Sending query : {}\n".format(query))
+
+        full_url = self._search_url + query
+
+        try:
+            response = requests.get(full_url)
+        except requests.exceptions.ConnectionError:
+            self._view.log_message("Error: Check your internet connection.\n")
+            return
+
+        if response.status_code != 200:
+            self._view.log_message("Error : {}\n".format(response.status_code))
+            return
+
+        printed_response = False
+        identifiers = []
+        i = True
+        for x in response.text.split('TR>'):
+            y = x.split('<TD')
+
+            if len(y) > 2:
+                year = y[2][1:5]
+                area = y[3].split('<i>')[1].split('</i>')[0]
+                expt = y[4].split('>')[1].split('<')[0]
+                expt_type = y[5].split('>')[3].split('<')[0]
+                run_numbers = y[6].split('"')
+
+                if len(run_numbers) > 4:
+
+                    if i:
+                        self._view.set_if_empty(expt, year, area)
+                        i = False
+
+                    title_string = x.split('tx=')[1].split('\"')[0]
+                    title = parse.unquote(title_string)
+
+                    run_number = run_numbers[3].split()[2]
+                    identifier = '{} Title: {}, Year: {}, Area: {}'.format(run_number, title, year, area)
+
+                    identifiers.append(identifier)
+                    printed_response = True
+
+        self._view.fill_list(identifiers)
+        if not printed_response:
+            self._view.log_message("No runs found.\n")
+
+        self._view.set_status_message('Done.')
+
+    def _on_download_clicked(self):
+        self._view.set_status_message('Downloading ... ')
+
+        downloads = self._assemble_downloads()
+        if downloads is None:
+            self._view.log_message('No runs specified.\n')
+            self._view.set_status_message('Done.')
+            return
+
+        self._download(downloads)
+
+    def _on_download_selected_clicked(self):
+        self._view.set_status_message('Downloading ... ')
+
+        downloads = self._assemble_downloads_from_search(True)
+        if downloads is None:
+            self._view.log_message('No runs specified.\n')
+            self._view.set_status_message('Done.')
+            return
+
+        self._download(downloads)
+
+    def _on_download_all_clicked(self):
+        self._view.set_status_message('Downloading ... ')
+
+        downloads = self._assemble_downloads_from_search(False)
+        if downloads is None:
+            self._view.log_message('Please finish filling in Expt Number, Year and Area.\n')
+            self._view.set_status_message('Done.')
+            return
+
+        self._download(downloads)
+
+    def _on_done_clicked(self):
+        if self._new_files:
+            self._view.done(MusrDownloadDialog.Codes.NEW_FILES)
+        else:
+            self._view.done(MusrDownloadDialog.Codes.NO_NEW_FILES)
+
+    def _on_save_to_clicked(self):
+        path = QtWidgets.QFileDialog.getExistingDirectory(self._view, 'Select directory to save MUD files to',
+                                                          self.__system_service.get_last_used_directory(),
+                                                          options=QtWidgets.QFileDialog.ShowDirsOnly)
+        if path:
+            self.__system_service.set_last_used_directory(path)
+            self._view.set_file(path)
 
     def _assemble_query(self):
         query = "?"
@@ -327,97 +432,6 @@ class MusrDownloadDialogPresenter:
 
         return directory + "{}{}".format(separator, download.split('/')[-1])
 
-    def _search_clicked(self):
-        self._view.set_status_message('Querying ... ')
-        query = self._assemble_query()
-
-        if query is None:
-            return
-
-        if len(query) < 2:
-            self._view.log_message("No query parameters filled.\n")
-        else:
-            self._view.log_message("Sending query : {}\n".format(query))
-
-        full_url = self._search_url + query
-
-        try:
-            response = requests.get(full_url)
-        except requests.exceptions.ConnectionError:
-            self._view.log_message("Error: Check your internet connection.\n")
-            return
-
-        if response.status_code != 200:
-            self._view.log_message("Error : {}\n".format(response.status_code))
-            return
-
-        printed_response = False
-        identifiers = []
-        i = True
-        for x in response.text.split('TR>'):
-            y = x.split('<TD')
-
-            if len(y) > 2:
-                year = y[2][1:5]
-                area = y[3].split('<i>')[1].split('</i>')[0]
-                expt = y[4].split('>')[1].split('<')[0]
-                expt_type = y[5].split('>')[3].split('<')[0]
-                run_numbers = y[6].split('"')
-
-                if len(run_numbers) > 4:
-
-                    if i:
-                        self._view.set_if_empty(expt, year, area)
-                        i = False
-
-                    title_string = x.split('tx=')[1].split('\"')[0]
-                    title = parse.unquote(title_string)
-
-                    run_number = run_numbers[3].split()[2]
-                    identifier = '{} Title: {}, Year: {}, Area: {}'.format(run_number, title, year, area)
-
-                    identifiers.append(identifier)
-                    printed_response = True
-
-        self._view.fill_list(identifiers)
-        if not printed_response:
-            self._view.log_message("No runs found.\n")
-
-        self._view.set_status_message('Done.')
-
-    def _download_clicked(self):
-        self._view.set_status_message('Downloading ... ')
-
-        downloads = self._assemble_downloads()
-        if downloads is None:
-            self._view.log_message('No runs specified.\n')
-            self._view.set_status_message('Done.')
-            return
-
-        self._download(downloads)
-
-    def _download_selected_clicked(self):
-        self._view.set_status_message('Downloading ... ')
-
-        downloads = self._assemble_downloads_from_search(True)
-        if downloads is None:
-            self._view.log_message('No runs specified.\n')
-            self._view.set_status_message('Done.')
-            return
-
-        self._download(downloads)
-
-    def _download_all_clicked(self):
-        self._view.set_status_message('Downloading ... ')
-
-        downloads = self._assemble_downloads_from_search(False)
-        if downloads is None:
-            self._view.log_message('Please finish filling in Expt Number, Year and Area.\n')
-            self._view.set_status_message('Done.')
-            return
-
-        self._download(downloads)
-
     def _download(self, downloads):
         good = 0
         if len(downloads) > 500:
@@ -449,18 +463,3 @@ class MusrDownloadDialogPresenter:
         self.__file_service.add_files(new_files)
         self._view.log_message('{}/{} Files downloaded successfully.\n'.format(good, len(downloads)))
         self._view.set_status_message('Done.')
-
-    def _done_clicked(self):
-        if self._new_files:
-            self._view.done(MusrDownloadDialog.Codes.NEW_FILES)
-        else:
-            self._view.done(MusrDownloadDialog.Codes.NO_NEW_FILES)
-
-    # noinspection PyCallByClass
-    def _save_to_clicked(self):
-        path = QtWidgets.QFileDialog.getExistingDirectory(self._view, 'Select directory to save MUD files to',
-                                                          self.__system_service.get_last_used_directory(),
-                                                          options=QtWidgets.QFileDialog.ShowDirsOnly)
-        if path:
-            self.__system_service.set_last_used_directory(path)
-            self._view.set_file(path)

--- a/beams/app/gui/dialogs/dialog_plot_file.py
+++ b/beams/app/gui/dialogs/dialog_plot_file.py
@@ -122,20 +122,14 @@ class PlotFileDialogPresenter:
         self._set_callbacks()
 
     def _set_callbacks(self):
-        self._view.b_apply.released.connect(lambda: self._apply_clicked())
-        self._view.b_apply_all.released.connect(lambda: self._apply_all_clicked())
-        self._view.b_cancel.released.connect(lambda: self._cancel_clicked())
-        self._view.b_skip.released.connect(lambda: self._skip_clicked())
-        self._view.b_plot.released.connect(lambda: self._plot_clicked())
-        self._view.c_file_list.currentIndexChanged.connect(lambda: self._file_choice_changed())
+        self._view.b_apply.released.connect(self._on_apply_clicked)
+        self._view.b_apply_all.released.connect(self._on_apply_all_clicked)
+        self._view.b_cancel.released.connect(self._on_cancel_clicked)
+        self._view.b_skip.released.connect(self._on_skip_clicked)
+        self._view.b_plot.released.connect(self._on_plot_clicked)
+        self._view.c_file_list.currentIndexChanged.connect(self._on_file_choice_changed)
 
-    def _is_all_formatted(self):
-        for k, v in self._formats.items():
-            if v is None:
-                return False
-        return True
-
-    def _apply_clicked(self):
+    def _on_apply_clicked(self):
         current_format = self._current_format()
 
         if not current_format[3]:
@@ -152,7 +146,7 @@ class PlotFileDialogPresenter:
         self._view.increment_current_file()
         self._view.set_status_message("Applied.")
 
-    def _apply_all_clicked(self):
+    def _on_apply_all_clicked(self):
         current_format = self._current_format()
 
         if not current_format[3]:
@@ -173,10 +167,10 @@ class PlotFileDialogPresenter:
 
         self._view.set_status_message("Applied.")
 
-    def _cancel_clicked(self):
+    def _on_cancel_clicked(self):
         self._view.done(PlotFileDialog.Codes.NO_FILES_PLOTTED)
 
-    def _skip_clicked(self):
+    def _on_skip_clicked(self):
         current_file = self._view.get_file()
 
         for run in self._runs:
@@ -189,13 +183,13 @@ class PlotFileDialogPresenter:
         if self._is_all_formatted():
             self._view.set_enabled_plot_button(True)
 
-    def _plot_clicked(self):
+    def _on_plot_clicked(self):
         if self._is_all_formatted():
             self._load_runs()
         else:
             self._view.set_enabled_plot_button(False)
 
-    def _file_choice_changed(self):
+    def _on_file_choice_changed(self):
         current_file = self._view.get_file()
         if len(current_file) < 2:
             self._view.done(PlotFileDialog.Codes.NO_FILES_PLOTTED)
@@ -204,6 +198,12 @@ class PlotFileDialogPresenter:
         current_hists = files.file(current_file).read_meta()[files.HIST_TITLES_KEY]
         self._view.set_first_histogram(current_hists)
         self._view.set_second_histogram(current_hists)
+
+    def _is_all_formatted(self):
+        for k, v in self._formats.items():
+            if v is None:
+                return False
+        return True
 
     def _load_runs(self):
         self._view.done(PlotFileDialog.Codes.FILES_PLOTTED)

--- a/beams/app/gui/dialogs/dialog_write_data.py
+++ b/beams/app/gui/dialogs/dialog_write_data.py
@@ -1,8 +1,7 @@
 
 import os
 
-from PyQt5 import QtWidgets, QtCore
-import numpy as np
+from PyQt5 import QtWidgets
 
 from app.util import qt_widgets, qt_constants
 from app.model import files, objects, services
@@ -173,7 +172,6 @@ class WriteDataDialogPresenter:
         self.__system_service = services.SystemService()
         self.__files = self.__service.get_files(self._view.files)
 
-        # fixme, we will want to allow for fits but for now we will just do runs
         unloaded = 0
         files_with_run_datasets = []
         for file in self.__files:
@@ -192,17 +190,20 @@ class WriteDataDialogPresenter:
         self._set_callbacks()
 
     def _set_callbacks(self):
-        self._view.radio_binned.clicked.connect(lambda: self._view.enabled_binning(self._view.is_binned()))
-        self._view.radio_full.clicked.connect(lambda: self._view.enabled_binning(self._view.is_binned()))
-        self._view.radio_fft.clicked.connect(lambda: self._view.enabled_binning(self._view.is_binned()))
-        self._view.radio_binned_size.textChanged.connect(lambda: self._bin_changed())
-        self._view.select_folder.released.connect(lambda: self._save_to_clicked())
-        self._view.write_file.released.connect(lambda: self._write_clicked())
-        self._view.write_all.released.connect(lambda: self._write_all_clicked())
-        self._view.done_button.released.connect(lambda: self._done_clicked())
-        self._view.skip_file.released.connect(lambda: self._skip_clicked())
+        self._view.radio_binned.clicked.connect(self._on_radio_checked)
+        self._view.radio_full.clicked.connect(self._on_radio_checked)
+        self._view.radio_fft.clicked.connect(self._on_radio_checked)
+        self._view.radio_binned_size.textChanged.connect(self._on_bin_changed)
+        self._view.select_folder.released.connect(self._on_save_to_clicked)
+        self._view.write_file.released.connect(self._on_write_clicked)
+        self._view.write_all.released.connect(self._on_write_all_clicked)
+        self._view.done_button.released.connect(self._on_done_clicked)
+        self._view.skip_file.released.connect(self._on_skip_clicked)
 
-    def _write_clicked(self):
+    def _on_radio_checked(self):
+        self._view.enabled_binning(self._view.is_binned())
+
+    def _on_write_clicked(self):
         self._view.set_status_message('Writing files ... ')
         current_file = self._view.get_current_file()
         if self._view.is_binned():
@@ -213,7 +214,7 @@ class WriteDataDialogPresenter:
             self._write_fft(current_file)
         self._view.set_status_message('Done.')
 
-    def _write_all_clicked(self):
+    def _on_write_all_clicked(self):
         self._view.set_status_message('Writing files ... ')
         for file in self._view.get_all_files():
 
@@ -225,7 +226,7 @@ class WriteDataDialogPresenter:
                 self._write_fft(file)
         self._view.set_status_message('Done.')
 
-    def _save_to_clicked(self):
+    def _on_save_to_clicked(self):
         # fixme only specifies for .asy files
         # noinspection PyCallByClass,PyArgumentList
         saved_file_path = QtWidgets.QFileDialog.getSaveFileName(self._view, 'Specify file',
@@ -239,7 +240,7 @@ class WriteDataDialogPresenter:
             self.__system_service.set_last_used_directory(path[0])
             self._view.set_file_path(saved_file_path)
 
-    def _skip_clicked(self):
+    def _on_skip_clicked(self):
         current_file = self._view.get_current_file()
         self._view.remove_current_file()
 
@@ -252,10 +253,10 @@ class WriteDataDialogPresenter:
                 self.__files.remove(file)
                 break
 
-    def _done_clicked(self):
+    def _on_done_clicked(self):
         self._view.done(0)
 
-    def _bin_changed(self):
+    def _on_bin_changed(self):
         try:
             float(self._view.get_bin_size())
             self._view.enable_writing(True)


### PR DESCRIPTION
- Renames all the event handlers in the presenter objects
- Cleans up code related to event handlers, including moving them to the top of presenter object right below the _set_callbacks method.
