### PR TITLE
Issue 135 - Fix issue where program crashes when fit equation is changed

### DIFF
--- a/beams/app/gui/fittingpanel.py
+++ b/beams/app/gui/fittingpanel.py
@@ -1278,8 +1278,8 @@ class FitTabPresenter(PanelPresenter):
 
         expression = "A(t) = " + self._view.get_expression()
 
-        self.__update_states = False
         if fit.is_valid_expression(expression):
+            self.__update_states = False
             self._view.highlight_input_red(self._view.input_fit_equation, False)
 
             variables = fit.parse(fit.split_expression(expression)[1])
@@ -1291,13 +1291,13 @@ class FitTabPresenter(PanelPresenter):
             self._view.add_parameter(symbol=fit.ALPHA)
             for var in variables:
                 self._view.add_parameter(symbol=var)
+
             self.__update_states = True
             self.update_parameter_table_states()
             self._plot_fit()
         else:
             self._view.highlight_input_red(self._view.input_fit_equation, True)
         self.__update_if_table_changes = True
-
 
     @QtCore.pyqtSlot()
     def _on_save_user_defined_function_clicked(self):


### PR DESCRIPTION
So it looks like the part of the program that actually adds and removes parameters from the config panel is in the `_on_function_input_changed()` method. Right now, it only updates the parameters if the expression input is valid, which seems right because it doesn't make sense to update the parameters if the equation is invalid. The issue was that `self._plot_fit()` was still being called even if the expression was invalid, which would lead to `get_parameters()` being called and iterating over parameters that don't exist anymore.

I moved the `_plot_fit()` call into the conditional that checks if the fit expression is valid, so that it is only called if the parameters have been updated by a new valid expression. This seems to prevent the crashes I was seeing, but I am not sure if it fixes all of the crashes or if it breaks any other functionality. 