### PR TITLE
Issue 184 - Add  Quit button to file menu

### DIFF
--- a/beams/app/gui/mainwindow.py
+++ b/beams/app/gui/mainwindow.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import qdarkstyle
 import darkdetect
@@ -156,6 +157,7 @@ class MainWindow(QtWidgets.QMainWindow):
         fileMenu = self.menuBar().addMenu(self.tr("&File"))
         fileMenu.addAction("&Save Session", self._action_save)
         fileMenu.addAction("&Open Session", self._action_open)
+        fileMenu.addAction(" &Quit BEAMS", self._action_quit)
 
         viewMenu = self.menuBar().addMenu(self.tr("&View"))
         theme_menu = viewMenu.addMenu(self.tr("&Change application theme"))
@@ -219,6 +221,9 @@ class MainWindow(QtWidgets.QMainWindow):
                 instance.setStyleSheet(qdarkstyle.load_stylesheet(palette=qdarkstyle.LightPalette))
             self.__system_service.set_theme_preference(self.__system_service.Themes.DEFAULT)
 
+
+    def _action_quit(self):
+        sys.exit()
 
 # noinspection PyArgumentList
 class StyleFile:

--- a/beams/app/gui/mainwindow.py
+++ b/beams/app/gui/mainwindow.py
@@ -157,7 +157,7 @@ class MainWindow(QtWidgets.QMainWindow):
         fileMenu = self.menuBar().addMenu(self.tr("&File"))
         fileMenu.addAction("&Save Session", self._action_save)
         fileMenu.addAction("&Open Session", self._action_open)
-        fileMenu.addAction(" &Quit BEAMS", self._action_quit)
+        fileMenu.addAction("&Quit BEAMS", self._action_quit)
 
         viewMenu = self.menuBar().addMenu(self.tr("&View"))
         theme_menu = viewMenu.addMenu(self.tr("&Change application theme"))

--- a/beams/app/gui/mainwindow.py
+++ b/beams/app/gui/mainwindow.py
@@ -158,7 +158,7 @@ class MainWindow(QtWidgets.QMainWindow):
         fileMenu.addAction("&Save Session", self._action_save)
         fileMenu.addAction("&Open Session", self._action_open)
         fileMenu.addSeparator()
-        fileMenu.addAction("&Quit BEAMS", self._action_quit)
+        fileMenu.addAction("&Quit", self._action_quit)
 
         viewMenu = self.menuBar().addMenu(self.tr("&View"))
         theme_menu = viewMenu.addMenu(self.tr("&Change application theme"))

--- a/beams/app/gui/mainwindow.py
+++ b/beams/app/gui/mainwindow.py
@@ -157,6 +157,7 @@ class MainWindow(QtWidgets.QMainWindow):
         fileMenu = self.menuBar().addMenu(self.tr("&File"))
         fileMenu.addAction("&Save Session", self._action_save)
         fileMenu.addAction("&Open Session", self._action_open)
+        fileMenu.addSeparator()
         fileMenu.addAction("&Quit BEAMS", self._action_quit)
 
         viewMenu = self.menuBar().addMenu(self.tr("&View"))


### PR DESCRIPTION
The extra space in front of the word " Quit" is not a mistake...it's necessary to get it to display on Mac.