### PR TITLE
Issue 181 - Fix session file size issue

### DIFF
--- a/beams/app/model/data_access.py
+++ b/beams/app/model/data_access.py
@@ -163,8 +163,14 @@ class FileDAO:
 
     def maximize(self, data):
         from app.model import objects
-        self.__database.file_table = {file_id: objects.FileDataset.build_from_persistent_data(file)
-                                      for file_id, file in data.items()}
+        file_datasets = {file_id: objects.FileDataset.build_from_persistent_data(file)
+                         for file_id, file in data.items()}
+
+        for _, fd in file_datasets.items():
+            if fd.dataset is not None:
+                fd.dataset = self.__database.run_table[fd.dataset]
+
+        self.__database.file_table = file_datasets
 
 
 class StyleDAO:

--- a/beams/app/model/files.py
+++ b/beams/app/model/files.py
@@ -1,5 +1,6 @@
 # Standard Library Packages
 import abc
+import gzip
 import os
 import pickle
 import sys
@@ -159,7 +160,7 @@ class BeamsSessionFile(ReadableFile):
     DATA_FORMAT = Format.PICKLED
 
     def read_data(self):
-        with open(self.file_path, 'rb') as session_file_object:
+        with gzip.GzipFile(self.file_path, 'rb') as session_file_object:
             try:
                 return pickle.load(session_file_object)
             except Exception as e:

--- a/beams/app/model/objects.py
+++ b/beams/app/model/objects.py
@@ -1254,7 +1254,7 @@ class FileDataset(PersistentObject):
             file_path=self.file_path,
             title=self.title,
             is_loaded=self.is_loaded,
-            dataset=None if self.dataset is None else self.dataset.get_persistent_data()
+            dataset=None if self.dataset is None else self.dataset.id
         )
 
     @staticmethod
@@ -1264,9 +1264,7 @@ class FileDataset(PersistentObject):
         file_dataset.title = data["title"]
         file_dataset.is_loaded = data["is_loaded"]
         file_dataset.id = data["id"]
-
-        dataset = data["dataset"]
-        file_dataset.dataset = None if dataset is None else RunDataset.build_from_persistent_data(dataset)
+        file_dataset.dataset = data["dataset"]
 
         return file_dataset
 

--- a/beams/app/model/services.py
+++ b/beams/app/model/services.py
@@ -3,6 +3,7 @@ import json
 import os
 import logging
 import pickle
+import gzip
 
 from PyQt5 import QtCore
 
@@ -705,7 +706,7 @@ class FileService:
         if not os.path.splitext(save_path)[-1] == '.beams':
             raise RuntimeError("Session file needs to have a .beams extension.")
 
-        with open(save_path, 'wb') as session_file_object:
+        with gzip.GzipFile(save_path, 'wb') as session_file_object:
             pickle.dump(self.__system_dao.get_database(), session_file_object)
 
         self.add_files([save_path])

--- a/beams/test/test_dao.py
+++ b/beams/test/test_dao.py
@@ -28,15 +28,17 @@ def database_with_runs():
 
 
 @pytest.fixture
-def database_with_files():
+def database_with_files(database_with_runs):
     f1, f2, f3 = (objects.FileDataset(files.file(resources.resource_path(rf"test/examples/histogram_data_{i}.dat")))
                   for i in range(3))
     f1.id = "1"
+    f1.dataset = database_with_runs.run_table["1"]
     f2.id = "2"
+    f2.dataset = database_with_runs.run_table["2"]
     f3.id = "3"
-    db = data_access.Database()
-    db.file_table = {f1.id: f1, f2.id: f2, f3.id: f3}
-    return db
+    f3.dataset = database_with_runs.run_table["3"]
+    database_with_runs.file_table = {f1.id: f1, f2.id: f2, f3.id: f3}
+    return database_with_runs
 
 
 @pytest.fixture

--- a/beams/test/test_models.py
+++ b/beams/test/test_models.py
@@ -809,7 +809,7 @@ class TestFileDatasets:
         file_dataset_minimized = file_dataset.get_persistent_data()
         file_dataset_maximized = file_dataset.build_from_persistent_data(file_dataset_minimized)
 
-        file_dataset.dataset = dataset.id
+        file_dataset_maximized.dataset = dataset  # cheating a little
         assert file_dataset_maximized.equals(file_dataset)
 
     def test_persistent_with_pickling(self):
@@ -836,5 +836,5 @@ class TestFileDatasets:
         file_dataset_minimized_unpickled = pickle.loads(pickle.dumps(file_dataset_minimized))
         file_dataset_maximized = file_dataset.build_from_persistent_data(file_dataset_minimized_unpickled)
 
-        file_dataset.dataset = dataset.id
+        file_dataset_maximized.dataset = dataset  # cheating a little
         assert file_dataset_maximized.equals(file_dataset)

--- a/beams/test/test_models.py
+++ b/beams/test/test_models.py
@@ -809,6 +809,7 @@ class TestFileDatasets:
         file_dataset_minimized = file_dataset.get_persistent_data()
         file_dataset_maximized = file_dataset.build_from_persistent_data(file_dataset_minimized)
 
+        file_dataset.dataset = dataset.id
         assert file_dataset_maximized.equals(file_dataset)
 
     def test_persistent_with_pickling(self):
@@ -835,4 +836,5 @@ class TestFileDatasets:
         file_dataset_minimized_unpickled = pickle.loads(pickle.dumps(file_dataset_minimized))
         file_dataset_maximized = file_dataset.build_from_persistent_data(file_dataset_minimized_unpickled)
 
+        file_dataset.dataset = dataset.id
         assert file_dataset_maximized.equals(file_dataset)


### PR DESCRIPTION
We are now zipping the files and removing the redundant data. With my test dataset we went from:

69.4 MB initially 
9.1 MB after adding zipping
4.6 MB after removing redundant data

Go team!