### PR TITLE
Issue-206 - Change default line color for fitting equation

### DIFF
--- a/beams/app/gui/fittingpanel.py
+++ b/beams/app/gui/fittingpanel.py
@@ -1746,7 +1746,7 @@ class FitTabPresenter(PanelPresenter):
         colors = {run.id: styles[run.id][self._style_service.Keys.DEFAULT_COLOR] for run in runs if
                   run.id in checked_run_ids}
         self._view.support_panel.tree.set_colors(colors)
-        colors['default'] = '#000000'
+        colors['default'] = '#888888'
 
         alphas = dict()
 


### PR DESCRIPTION
### Describe your changes

Closes #206 
Just changed the default line color in the fitting panel to be a gray that should be visible in both dark and light mode.

### Checklist before merging your PR
- [x] I have tagged the relevant issues in this PR
- [x] I have performed a self-review of my code
- [x] I have documented my code as necessary for clarity
- [x] I have ensured the tests are passing
- [x] I have written or updated tests as necessary
- [x] I have updated the README if necessary
- [x] I have checked any security advisories brought up by the CodeQL action
