### PR TITLE
Issue-186 - add reduced chi squared to .fit export

### DIFF
--- a/beams/app/model/objects.py
+++ b/beams/app/model/objects.py
@@ -1067,6 +1067,7 @@ class FitDataset(PersistentObject):
 
         for name, v in f.parameters.items():  # getting the column headers
             fit_parameters_string += "{:<8}\t".format(name)
+        fit_parameters_string += "{:<11}\t".format("Reduced \u03C7\u00B2")
         fit_parameters_string += "\n"
 
         fit_list = self.__sort_fit_list(list(self.fits.values()), order_by_key)
@@ -1077,7 +1078,7 @@ class FitDataset(PersistentObject):
                 fit_parameters_string += "{:<12}\t".format(f.meta[order_by_key])
             for name, v in f.parameters.items():
                 fit_parameters_string += "{:<8}\t".format("{:.5f}".format(v.value))
-            # run = services.RunService().get_runs_by_ids([f.run_id])[0]
+            fit_parameters_string += "{:<11.4f}\t".format(f.goodness)
             fit_parameters_string += "\n"
 
         # Writing the Verbose Section
@@ -1112,6 +1113,7 @@ class FitDataset(PersistentObject):
                                                                                                      v.uncertainty,
                                                                                                      v.lower,
                                                                                                      v.upper) + "\n"
+            fit_parameters_string += "\n\t{:<18}{:<8.4f}\n".format("Reduced \u03C7\u00B2", f.goodness)
 
             fit_parameters_string += "\n"
         return fit_parameters_string


### PR DESCRIPTION
### Describe your changes
Closes #186 

I added the reduced chi squared value to both the summary section and the verbose section of the fit export. @benfrandsen does this look like what you're looking for approximately?

![Screen Shot 2022-04-16 at 11 28 51 AM](https://user-images.githubusercontent.com/31145168/163685333-03d623dc-3228-4c5b-8c9a-20fd729e9970.png)



### Checklist before merging your PR
- [x] I have tagged the relevant issues in this PR
- [x] I have performed a self-review of my code
- [x] I have documented my code as necessary for clarity
- [x] I have ensured the tests are passing
- [x] I have written or updated tests as necessary
- [x] I have updated the README if necessary
- [x] I have checked any security advisories brought up by the CodeQL action
